### PR TITLE
Fix minor typos

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -134,7 +134,7 @@
 		{/if}
 		<p class="mt-6 text-center text-gray-600 dark:text-gray-400 italic">
 			This is a list of some of the organizations our members have worked with. Not all
-			organisations listed endorse or are affiliated with MAIA.
+			organizations listed endorse or are affiliated with MAIA.
 		</p>
 	</SectionContainer>
 </PageLayout>

--- a/src/routes/about/about.svelte
+++ b/src/routes/about/about.svelte
@@ -10,13 +10,13 @@
 		MAIA is an MIT club for people worried about human extinction due to AI.  <sup><a href="https://aisst.ai/non-technical-intro-to-ai-safety">[Why care about AI Safety?]</a></sup>
 	</p>
 	<p>
-		Our job is  to support education, research, and careers for our members. In doing 
+		Our job is to support education, research, and careers for our members. In doing 
 		so, we have become a hub for folk from across Boston to engage with events, 
 		opportunities, and people in AI Safety. We began in 2022, and now have membership 
 		in the hundreds. 
 	</p>
 	<p>
-		We get funding from <a href="https://coefficientgiving.org/">Coeffeicient Giving</a> 
+		We get funding from <a href="https://coefficientgiving.org/">Coefficient Giving</a> 
 		(FKA Open Philanthropy). Our parent organization is 
 		<a href="https://www.cbai.ai/">Cambridge Boston Alignment Initiative</a> (CBAI), 
 		which supports both us and our sister organization at Harvard, 

--- a/src/routes/getinvolved/AISFML.svelte
+++ b/src/routes/getinvolved/AISFML.svelte
@@ -32,7 +32,7 @@
 	
 	<p class="mt-2">
 	We run AISF every Fall and Spring, with applications opening early into both semesters.
-	There are no open applications now, but you can stay up to date via our mailing list list.
+	There are no open applications now, but you can stay up to date via our mailing list.
 	</p>
 
 	<!-- UNCOMMENT THIS WHEN AN APPLICATION OPENS -->

--- a/src/routes/getinvolved/Bootcamps.svelte
+++ b/src/routes/getinvolved/Bootcamps.svelte
@@ -13,10 +13,10 @@
 	<p class="mt-2 mb-2">
 		The bootcamp is <a href="https://www.cbai.ai/ml-bootcamp">CAMBRIA</a> (Cambridge Bootcamp for Research in Interpretability and Alignment).
 		It is in-person, with teaching assistants experienced with ML and AI safety
-		research. We follow the highly-rated ARENA curriculum designed provides a 
+		research. We follow the highly-rated ARENA curriculum, which provides a 
 		<b>thorough, hands-on introduction to state-of-the-art ML techniques</b> 
 		(e.g. transformers, deep RL, mechanistic interpretability) and is meant to get you to the level
-		of replicating ML papers in PyTorch. The program’s only prerequisites are comfort with Python and
+		of replicating ML papers in PyTorch. The program's only prerequisites are comfort with Python and
 		introductory linear algebra.
 	</p>
 	<div class="mt-8">


### PR DESCRIPTION
Fixed a few typos and grammar errors across the website:

- Fix British spelling 'organisations' → 'organizations' on main page
- Remove double space in about page  
- Fix misspelling 'Coeffeicient' → 'Coefficient'
- Fix grammar 'curriculum designed provides' → 'curriculum, which provides'
- Remove duplicate word 'mailing list list' → 'mailing list'

Co-authored-by: Claude <noreply@anthropic.com>